### PR TITLE
Fix SVG extraction from AI response

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import json
 import logging
 from flask_cors import CORS
 import re
+import html
 import base64
 from io import BytesIO
 import cairosvg
@@ -1444,13 +1445,25 @@ Create a single, perfectly combined SVG that merges both elements beautifully.""
             return simple_combine_svgs_fallback(text_svg_code, traced_svg_code)
 
         ai_response = response_data["choices"][0]["message"]["content"]
-        
-        # Extract SVG code from the response
-        svg_pattern = r'<svg.*?</svg>'
-        svg_match = re.search(svg_pattern, ai_response, re.DOTALL)
-        
+        logger.debug(f"AI combination raw response: {ai_response[:200]}...")
+
+        # Handle fenced code blocks
+        combined_svg = ai_response.strip()
+        if "```" in combined_svg:
+            code_match = re.search(r'```(?:svg)?\s*(.*?)\s*```', combined_svg, re.DOTALL)
+            if code_match:
+                combined_svg = code_match.group(1).strip()
+
+        # Unescape HTML entities
+        combined_svg = html.unescape(combined_svg)
+
+        # Remove optional XML declarations before the <svg> element
+        combined_svg = re.sub(r'^<\?xml[^>]*>\s*', '', combined_svg)
+
+        svg_match = re.search(r'<svg[^>]*>.*?</svg>', combined_svg, re.DOTALL)
+
         if svg_match:
-            combined_svg = svg_match.group(0)
+            combined_svg = svg_match.group(0).strip()
             logger.info("AI successfully combined SVGs")
             return combined_svg
         else:


### PR DESCRIPTION
## Summary
- improve AI response handling to reliably extract SVG
- strip XML declarations before SVG extraction

## Testing
- `python -m py_compile app.py`
- `python test_server.py` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6858942a514c8323b76b9b23ec869f27